### PR TITLE
UPDATE: node and redis are in a container now using docker

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+
+RUN npx prisma generate
+
+EXPOSE 8000
+
+CMD ["node", "index.js"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  backend:
+    build: .
+    container_name: node-backend
+    ports:
+      - "${PORT}:${PORT}"
+    env_file:
+      - .env
+    depends_on:
+      - redis
+    volumes:
+      - .:/app
+    restart: always
+
+  redis:
+    image: redis:alpine
+    container_name: redis-server
+    ports:
+      - "${REDIS_PORT}:${REDIS_PORT}"
+    restart: always

--- a/backend/index.js
+++ b/backend/index.js
@@ -8,7 +8,7 @@ const templateRouter = require("./Routes/template_routes");
 
 require("dotenv/config");
 
-const PORT = process.env.PORT;
+const PORT = process.env.PORT || 8000;
 
 server.use(cors());
 server.use(express.json());

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
done with image and container

for building run 
docker-compose up --build -d (it will run in docker env uses build caches)

it will make the container up and running 

to expose port manually
docker run -d -p 9091:PORT -e PORT 9091 image_name
docker exec -it container_id bash

do the same for both nodeJS and redis 

but as we have yml file just compose and build it 
it will automatically make all required containers up and running